### PR TITLE
Added href='javascript:;' to some links

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -559,7 +559,7 @@ function Graph() {
             fullText +=
                 "<div class='event-date'>" +
                     formatDate(e.date, e.datePrecision) +
-                    "<a class='report-button' id='report" + i + "'>Flag as wrong</a>" +
+                    "<a href='javascript:;' class='report-button' id='report" + i + "'>Flag as wrong</a>" +
                 "</div>";
 
             fullText +=
@@ -635,7 +635,7 @@ function Graph() {
 
         return descStart +
             "<span id='ellipsis" + continueCount + "'>...</span>" +
-            "<a class='continue-button' id='continue" + continueCount + "'>continue</a>" +
+            "<a href='javascript:;' class='continue-button' id='continue" + continueCount + "'>continue</a>" +
             "<span class='continue-text' id='hidden" + continueCount + "'>" + descEnd + "</span>"
     }
 


### PR DESCRIPTION
href="javascript:;" is better than href="#" because it doesn't add another entry to the browser history or reload anything but it is messier.

This should make the link cursors default to pointer.
